### PR TITLE
Converters rewritten as QRunnable-like objects

### DIFF
--- a/ftCLI/Lib/converters/options.py
+++ b/ftCLI/Lib/converters/options.py
@@ -1,0 +1,51 @@
+class Options(object):
+    def __init__(self):
+        self.recalc_timestamp = False
+        self.output_dir = None
+        self.overwrite = True
+
+
+class WebToSFNTOptions(Options):
+    def __init__(self):
+        super().__init__()
+        self.woff = True
+        self.woff2 = True
+
+
+class SFNTToWebOptions(Options):
+    def __init__(self):
+        super().__init__()
+        self.woff = True
+        self.woff2 = True
+
+
+class CFFToTrueTypeOptions(Options):
+    def __init__(self):
+        super().__init__()
+        self.max_err = 1.0
+        self.post_format = 2.0
+        self.reverse_direction = True
+
+
+class Var2StaticOptions(Options):
+    def __init__(self):
+        super().__init__()
+        self.cleanup = True
+        self.update_name_table = True
+
+
+class TrueTypeToCFFOptions(Options):
+    def __init__(self):
+        super().__init__()
+        self.tolerance: float = 1.0
+        self.charstring_source = "qu2cu"
+        self.subroutinize = True
+        self.check_outlines = False
+        self.safe_mode = False
+        self.remove_glyphs = True
+        self.scale_upm = False
+
+
+class TTCollectionToSFNTOptions(Options):
+    def __init__(self):
+        super().__init__()

--- a/ftCLI/Lib/converters/sfnt_to_web.py
+++ b/ftCLI/Lib/converters/sfnt_to_web.py
@@ -1,4 +1,57 @@
+import os
+import time
+
+from fontTools.misc.cliTools import makeOutputFileName
+
 from ftCLI.Lib.Font import Font
+from ftCLI.Lib.converters.options import SFNTToWebOptions
+from ftCLI.Lib.utils.click_tools import generic_info_message, file_saved_message, generic_error_message
+
+
+class JobRunner_ft2wf(object):
+    def __init__(self):
+        super().__init__()
+        self.options = SFNTToWebOptions()
+
+    def run(self, files) -> None:
+
+        count = 0
+        for file in files:
+            t = time.time()
+            count += 1
+            print()
+            generic_info_message(f"Converting file {count} of {len(files)}: {os.path.basename(file)}")
+
+            try:
+                font = Font(file, recalcTimestamp=self.options.recalc_timestamp)
+
+                if font.flavor is not None:
+                    continue
+
+                if self.options.woff:
+                    converter = SFNTToWeb(font=font, flavor="woff")
+                    web_font = converter.run()
+                    extension = web_font.get_real_extension()
+                    output_file = makeOutputFileName(
+                        file, extension=extension, outputDir=self.options.output_dir, overWrite=self.options.overwrite
+                    )
+                    web_font.save(output_file, reorderTables=False)
+                    file_saved_message(output_file)
+                    generic_info_message(f"Elapsed time: {round(time.time() - t, 3)} seconds")
+
+                if self.options.woff2:
+                    converter = SFNTToWeb(font=font, flavor="woff2")
+                    web_font = converter.run()
+                    extension = web_font.get_real_extension()
+                    output_file = makeOutputFileName(
+                        file, extension=extension, outputDir=self.options.output_dir, overWrite=self.options.overwrite
+                    )
+                    web_font.save(output_file, reorderTables=False)
+                    file_saved_message(output_file)
+                    generic_info_message(f"Elapsed time: {round(time.time() - t, 3)} seconds")
+
+            except Exception as e:
+                generic_error_message(e)
 
 
 class SFNTToWeb(object):

--- a/ftCLI/Lib/converters/ttc_to_sfnt.py
+++ b/ftCLI/Lib/converters/ttc_to_sfnt.py
@@ -1,0 +1,51 @@
+import os.path
+import time
+
+from fontTools.misc.cliTools import makeOutputFileName
+from fontTools.ttLib import TTCollection
+
+from ftCLI.Lib.converters.options import TTCollectionToSFNTOptions
+from ftCLI.Lib.utils.click_tools import generic_info_message, file_saved_message, generic_error_message
+
+
+class JobRunner_ttc2sfnt(object):
+    def __init__(self):
+        super().__init__()
+        self.options = TTCollectionToSFNTOptions()
+
+    def run(self, files) -> None:
+        count = 0
+        extracted_files = 0
+        start_time = time.time()
+
+        for file in files:
+            count += 1
+            t = time.time()
+
+            try:
+                print()
+                generic_info_message(f"Converting file {count} of {len(files)}: {os.path.basename(file)}")
+
+                ttc = TTCollection(file)
+                for font in ttc.fonts:
+                    font.recalcTimestamp = self.options.recalc_timestamp
+                    file_name = font["name"].getDebugName(6)
+                    extension = ".otf" if font.sfntVersion == "OTTO" else ".ttf"
+                    output_file = makeOutputFileName(
+                        file_name,
+                        outputDir=self.options.output_dir,
+                        extension=extension,
+                        overWrite=self.options.overwrite,
+                    )
+                    font.save(output_file)
+                    generic_info_message(f"Elapsed time: {round(time.time() - t, 3)} seconds")
+                    file_saved_message(output_file)
+                    extracted_files += 1
+
+            except Exception as e:
+                generic_error_message(e)
+
+        print()
+        generic_info_message(f"Total TTC files   : {len(files)}")
+        generic_info_message(f"Extracted files   : {extracted_files}")
+        generic_info_message(f"Elapsed time      : {round(time.time() - start_time, 3)} seconds")

--- a/ftCLI/Lib/converters/ttf_to_otf.py
+++ b/ftCLI/Lib/converters/ttf_to_otf.py
@@ -12,44 +12,28 @@ from fontTools.ttLib import TTFont
 from fontTools.ttLib.scaleUpem import scale_upem
 
 from ftCLI.Lib.Font import Font
+from ftCLI.Lib.converters.options import TrueTypeToCFFOptions
 from ftCLI.Lib.utils.click_tools import file_saved_message, generic_info_message, generic_error_message
 from ftCLI.Lib.utils.subsetter import BaseSubsetter
 
 
-class TrueTypeToCFFOptions(object):
-    def __init__(self):
-        self.tolerance: float = 1.0
-        self.charstring_source = "qu2cu"
-        self.subroutinize = True
-        self.check_outlines = False
-        self.safe_mode = False
-        self.remove_glyphs = True
-        self.scale_upm = False
-
-        self.recalc_timestamp = False
-        self.output_dir = None
-        self.overwrite = True
-
-
 class JobRunner_ttf2otf(object):
-    def __init__(self, files):
+    def __init__(self):
         super().__init__()
-        self.files = files
         self.options = TrueTypeToCFFOptions()
-        self.is_killed = False
 
-    def run(self) -> None:
+    def run(self, files) -> None:
         count = 0
         converted_files_count = 0
         start_time = time.time()
 
-        for file in self.files:
+        for file in files:
             t = time.time()
             count += 1
 
             try:
                 print()
-                generic_info_message(f"Converting file {count} of {len(self.files)}: {file}")
+                generic_info_message(f"Converting file {count} of {len(files)}: {file}")
 
                 # Temporary workaround, waiting to understand the reason why, if we scale the UPM of a Font object
                 # instead of a TTFont object, the new UPM values is wrong
@@ -123,7 +107,7 @@ class JobRunner_ttf2otf(object):
                 generic_error_message(e)
 
         print()
-        generic_info_message(f"Total files       : {len(self.files)}")
+        generic_info_message(f"Total files       : {len(files)}")
         generic_info_message(f"Converted files   : {converted_files_count}")
         generic_info_message(f"Elapsed time      : {round(time.time() - start_time, 3)} seconds")
 
@@ -135,7 +119,7 @@ class TrueTypeToCFF(object):
 
     def run(self):
         if self.options.remove_glyphs:
-            self.purge_glyphs()
+            self.remove_glyphs()
 
         charstrings = {}
 
@@ -222,7 +206,7 @@ class TrueTypeToCFF(object):
         )
         return post_info
 
-    def purge_glyphs(self):
+    def remove_glyphs(self):
         glyph_ids_to_remove = []
         for g in [".null", "NUL", "NULL", "uni0000", "CR", "nonmarkingreturn", "uni000D"]:
             try:

--- a/ftCLI/Lib/converters/variable_to_static.py
+++ b/ftCLI/Lib/converters/variable_to_static.py
@@ -5,6 +5,7 @@ from fontTools.varLib.instancer import instantiateVariableFont, OverlapMode
 from pathvalidate import sanitize_filename
 
 from ftCLI.Lib.VFont import VariableFont
+from ftCLI.Lib.converters.options import Var2StaticOptions
 from ftCLI.Lib.utils.click_tools import (
     generic_warning_message,
     generic_info_message,
@@ -13,17 +14,9 @@ from ftCLI.Lib.utils.click_tools import (
 )
 
 
-class Options(object):
-    def __init__(self):
-        self.cleanup = True
-        self.update_name_table = True
-        self.output_dir = None
-        self.overwrite = True
-
-
 class VariableToStatic(object):
     def __init__(self):
-        self.options = Options()
+        self.options = Var2StaticOptions()
 
     def run(self, variable_font: VariableFont, instances: list = None):
         start_time = time.time()

--- a/ftCLI/Lib/converters/web_to_sfnt.py
+++ b/ftCLI/Lib/converters/web_to_sfnt.py
@@ -1,10 +1,66 @@
+import os
+import time
+
+from fontTools.misc.cliTools import makeOutputFileName
+
+from ftCLI.Lib.converters.options import WebToSFNTOptions
 from ftCLI.Lib.Font import Font
+from ftCLI.Lib.utils.click_tools import generic_info_message, generic_error_message, file_saved_message
 
 
-class WebToSFNT(object):
-    def __init__(self, font: Font):
-        self.font = font
+class JobRunner_wf2ft(object):
+    def __init__(self):
+        super().__init__()
+        self.options = WebToSFNTOptions()
 
-    def run(self) -> Font:
-        self.font.flavor = None
-        return self.font
+    def run(self, files) -> None:
+        count = 0
+        converted_files_count = 0
+        start_time = time.time()
+
+        for file in files:
+            t = time.time()
+            count += 1
+
+            try:
+                print()
+                generic_info_message(f"Converting file {count} of {len(files)}: {os.path.basename(file)}")
+                font = Font(file, recalcTimestamp=self.options.recalc_timestamp)
+
+                if not font.flavor:
+                    continue
+                if not self.options.woff:
+                    if font.flavor == "woff":
+                        continue
+                if not self.options.woff2:
+                    if font.flavor == "woff2":
+                        continue
+
+                old_extension = font.get_real_extension()
+                if self.options.woff and self.options.woff2:
+                    suffix = old_extension
+                else:
+                    suffix = ""
+                font.flavor = None
+                new_extension = font.get_real_extension()
+                output_file = makeOutputFileName(
+                    file,
+                    extension=new_extension,
+                    suffix=suffix,
+                    outputDir=self.options.output_dir,
+                    overWrite=self.options.overwrite,
+                )
+
+                font.save(output_file)
+                generic_info_message(f"Elapsed time: {round(time.time() - t, 3)} seconds")
+                file_saved_message(output_file)
+                converted_files_count += 1
+
+            except Exception as e:
+                generic_error_message(e)
+
+        print()
+        generic_info_message(f"Total files       : {len(files)}")
+        generic_info_message(f"Converted files   : {converted_files_count}")
+        generic_info_message(f"Elapsed time      : {round(time.time() - start_time, 3)} seconds")
+

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="font-CLI",
-    version="0.9.12",
+    version="0.9.13.dev0",
     description="A set of command line tools to edit fonts with FontTools",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -29,7 +29,6 @@ setuptools.setup(
         "rich>=13.3.5",
         "skia-pathops==0.7.4",
         "ttfautohint-py==0.5.1",
-        # "ufo2ft==2.31.1",
         "zopfli==0.2.2",
     ],
     classifiers=[


### PR DESCRIPTION
All the converters under Lib.converters have been rewritten as PyQt QRunnable-like objects. Consequently, all commands in commands.ftcli_converter have been adapeted.