### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,6 @@ Converts web fonts (WOFF and WOFF2) to SFNT fonts (TTF or OTF).
                                   woff2 flavored web fonts to SFNT fonts
                                   (TrueType or OpenType). Use this option to
                                   convert only woff or woff2 flavored web fonts.
-    -d, --delete-source-file      Deletes the source files after conversion.
     -out, --output-dir DIRECTORY  Specify the directory where output files are
                                   to be saved. If output_dir doesn't exist, will
                                   be created. If not specified, files are saved

--- a/README.md
+++ b/README.md
@@ -696,9 +696,9 @@ Exports static instances from variable fonts.
                                   nameIDs are deleted from name table. Use --no-
                                   cleanup to keep STAT table and prevent axis
                                   nameIDs to be deleted from name table.
-    --update-name-table           Update the instantiated font's `name` table.
-                                  Input font must have a STAT table with Axis
-                                  Value Tables
+    --no-update-name-table        Prevent updating instantiated fonts `name`
+                                  table. Input fonts must have a STAT table with
+                                  Axis Value Tables.
     -out, --output-dir DIRECTORY  Specify the directory where output files are
                                   to be saved. If output_dir doesn't exist, will
                                   be created. If not specified, files are saved

--- a/ftCLI/Lib/Font.py
+++ b/ftCLI/Lib/Font.py
@@ -9,8 +9,8 @@ from fontTools.pens.boundsPen import BoundsPen
 from fontTools.pens.recordingPen import DecomposingRecordingPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
 from fontTools.ttLib import TTFont, registerCustomTableClass, newTable
-from ftCLI.Lib.utils.misc import intListToNum
-from ftCLI.Lib.utils.misc import calcCodePageRanges
+from ftCLI.Lib.utils.misc import int_list_to_num
+from ftCLI.Lib.utils.misc import calc_code_page_ranges
 
 from ftCLI.Lib import constants
 from ftCLI.Lib.tables.OS_2 import TableOS2
@@ -308,9 +308,9 @@ class Font(TTFont):
             if table.isUnicode():
                 unicodes.update(table.cmap.keys())
 
-        code_page_ranges = calcCodePageRanges(unicodes)
-        codepage_range1 = intListToNum(code_page_ranges, 0, 32)
-        codepage_range2 = intListToNum(code_page_ranges, 32, 32)
+        code_page_ranges = calc_code_page_ranges(unicodes)
+        codepage_range1 = int_list_to_num(code_page_ranges, 0, 32)
+        codepage_range2 = int_list_to_num(code_page_ranges, 32, 32)
 
         return codepage_range1, codepage_range2
 

--- a/ftCLI/Lib/converters/variable_to_static.py
+++ b/ftCLI/Lib/converters/variable_to_static.py
@@ -80,4 +80,4 @@ class VariableToStatic(object):
 
         print()
         generic_info_message(f"Total instances : {len(instances)}")
-        generic_info_message(f"Elapsed time    : {round(time.time() - start_time)} seconds")
+        generic_info_message(f"Elapsed time    : {round(time.time() - start_time, 3)} seconds")

--- a/ftCLI/Lib/converters/web_to_sfnt.py
+++ b/ftCLI/Lib/converters/web_to_sfnt.py
@@ -36,17 +36,11 @@ class JobRunner_wf2ft(object):
                     if font.flavor == "woff2":
                         continue
 
-                old_extension = font.get_real_extension()
-                if self.options.woff and self.options.woff2:
-                    suffix = old_extension
-                else:
-                    suffix = ""
                 font.flavor = None
                 new_extension = font.get_real_extension()
                 output_file = makeOutputFileName(
                     file,
                     extension=new_extension,
-                    suffix=suffix,
                     outputDir=self.options.output_dir,
                     overWrite=self.options.overwrite,
                 )

--- a/ftCLI/Lib/utils/misc.py
+++ b/ftCLI/Lib/utils/misc.py
@@ -71,33 +71,33 @@ def wrap_string(string: str, width: int, initial_indent: int, indent: int, max_l
 
 # Functions copied from ufo2ft 2.31.1
 
-def intListToNum(intList, start, length):
-    all = []
-    bin = ""
+def int_list_to_num(intList, start, length):
+    all_integers = []
+    binary = ""
     for i in range(start, start + length):
         if i in intList:
             b = "1"
         else:
             b = "0"
-        bin = b + bin
+        binary = b + binary
         if not (i + 1) % 8:
-            all.append(bin)
-            bin = ""
-    if bin:
-        all.append(bin)
-    all.reverse()
-    all = " ".join(all)
-    return binary2num(all)
+            all_integers.append(binary)
+            binary = ""
+    if binary:
+        all_integers.append(binary)
+    all_integers.reverse()
+    all_integers = " ".join(all_integers)
+    return binary2num(all_integers)
 
 
-def binary2num(bin):
-    bin = strjoin(bin.split())
-    l = 0
-    for digit in bin:
-        l = l << 1
+def binary2num(binary):
+    binary = strjoin(binary.split())
+    num = 0
+    for digit in binary:
+        num = num << 1
         if digit != "0":
-            l = l | 0x1
-    return l
+            num = num | 0x1
+    return num
 
 
 def strjoin(iterable, joiner=""):
@@ -111,7 +111,7 @@ def tostr(s, encoding="ascii", errors="strict"):
         return s
 
 
-def calcCodePageRanges(unicodes):
+def calc_code_page_ranges(unicodes):
     """Given a set of Unicode codepoints (integers), calculate the
     corresponding OS/2 CodePage range bits.
     This is a direct translation of FontForge implementation:

--- a/ftCLI/commands/ftcli_converter.py
+++ b/ftCLI/commands/ftcli_converter.py
@@ -3,16 +3,13 @@ import time
 
 import click
 import fontTools.ttLib
-from fontTools.misc.cliTools import makeOutputFileName
 
-from ftCLI.Lib.Font import Font
 from ftCLI.Lib.utils.cli_tools import check_output_dir, check_input_path
 from ftCLI.Lib.utils.click_tools import (
     add_file_or_path_argument,
     add_common_options,
     generic_error_message,
     generic_info_message,
-    file_saved_message,
     select_instance_coordinates,
 )
 
@@ -211,7 +208,6 @@ def ft2wf(input_path, flavor=None, outputDir=None, recalcTimestamp=False, overWr
     """
     Converts SFNT fonts (TTF or OTF) to web fonts (WOFF and/or WOFF2)
     """
-    from ftCLI.Lib.converters.sfnt_to_web import SFNTToWeb
 
     files = check_input_path(input_path, allow_extensions=[".otf", ".ttf"])
     output_dir = check_output_dir(input_path=input_path, output_path=outputDir)

--- a/ftCLI/commands/ftcli_converter.py
+++ b/ftCLI/commands/ftcli_converter.py
@@ -296,14 +296,17 @@ def variable_to_static():
     default=True,
     help="""
               By default, STAT table is dropped and axis nameIDs are deleted from name table. Use --no-cleanup to keep
-              STAT table and prevent axis nameIDs to be deleted from name table.""",
+              STAT table and prevent axis nameIDs to be deleted from name table.
+              """,
 )
 @click.option(
-    "--update-name-table",
+    "--no-update-name-table",
+    "update_name_table",
     is_flag=True,
     default=True,
     help="""
-              Update the instantiated font's `name` table. Input font must have a STAT table with Axis Value Tables
+              Prevent updating instantiated fonts `name` table. Input fonts must have a STAT table with Axis Value
+              Tables.
               """,
 )
 @add_common_options()
@@ -311,7 +314,7 @@ def var2static(
     input_path,
     select_instance=False,
     cleanup=True,
-    update_name_table=False,
+    update_name_table=True,
     outputDir=None,
     recalcTimestamp=False,
     overWrite=True,
@@ -367,8 +370,9 @@ def var2static(
         except Exception as e:
             generic_error_message(e)
 
-        generic_info_message(f"Total files     : {len(files)}")
-        generic_info_message(f"Elapsed time    : {round(time.time() - start_time)} seconds")
+    print()
+    generic_info_message(f"Total files  : {len(files)}")
+    generic_info_message(f"Elapsed time : {round(time.time() - start_time, 3)} seconds")
 
 
 cli = click.CommandCollection(


### PR DESCRIPTION
ftcli converter: removed unused imports
ftcli converter var2static: fixed output messages
ftcli converter var2static: update_name_table default set to True
ftcli converter wf2ft: save files without old extension as suffix
Lib.utils.misc: some functions copied from ufo2ft redefined bin and all builtins.