### PR TITLE
Minor fixes

### DIFF
--- a/ftCLI/Lib/cui/CUI.py
+++ b/ftCLI/Lib/cui/CUI.py
@@ -663,7 +663,7 @@ def print_instances(variable_font: VariableFont):
     table.add_column("subfamilyNameID")
     table.add_column("postscriptNameID")
 
-    for i, instance in enumerate(instances):
+    for instance in instances:
 
         subfamily_name = f"{instance.subfamilyNameID}: " \
                          f"{variable_font.name_table.getDebugName(instance.subfamilyNameID)}"

--- a/ftCLI/commands/ftcli_utils.py
+++ b/ftCLI/commands/ftcli_utils.py
@@ -115,11 +115,13 @@ def font_organizer(
             output_dir = os.path.join(os.path.dirname(file))
 
             if sort_by_manufacturer:
-                manufacturer = font.name_table.getDebugName(8).strip()
-                if manufacturer == "":
-                    manufacturer = font.os_2_table.achVendID.strip().strip("\x00")
-                if manufacturer != "":
-                    output_dir = os.path.join(output_dir, manufacturer)
+                manufacturer = font.name_table.getDebugName(8)  # Manufacturer Nane
+                if not manufacturer:
+                    manufacturer = font.name_table.getDebugName(9)  # Designer
+                if not manufacturer:
+                    manufacturer = font.os_2_table.achVendID  # achVendID
+                if manufacturer:
+                    output_dir = os.path.join(output_dir, manufacturer.strip().strip("\x00"))
 
             output_dir = os.path.join(output_dir, family_name)
 


### PR DESCRIPTION
- `Lib.cui.CUI`: removed an unused variable
- `commands.utils font-roganizer`: use OS/2.achVendID as fallback string when sorting by manufacturer and nor nameID8 nor nameID9 are present
