### PR TITLE
Fixes

### DIFF
--- a/ftCLI/Lib/converters/ttf_to_otf.py
+++ b/ftCLI/Lib/converters/ttf_to_otf.py
@@ -69,7 +69,7 @@ class JobRunner_ttf2otf(object):
                     ttf2otf_converter_temp = TrueTypeToCFF(source_font)
                     ttf2otf_converter_temp.options.charstring_source = "t2"
                     ttf2otf_converter_temp.options.subroutinize = False
-                    ttf2otf_converter_temp.options.purge_glyphs = self.options.remove_glyphs
+                    ttf2otf_converter_temp.options.remove_glyphs = self.options.remove_glyphs
                     temp_cff_font = ttf2otf_converter_temp.run()
 
                     # ... and convert it back to a temporary TTF file that will be used for conversion
@@ -85,7 +85,7 @@ class JobRunner_ttf2otf(object):
                 ttf2otf_converter.options.charstring_source = "qu2cu"
                 ttf2otf_converter.options.tolerance = tolerance
                 ttf2otf_converter.options.subroutinize = self.options.subroutinize
-                ttf2otf_converter.options.purge_glyphs = self.options.remove_glyphs
+                ttf2otf_converter.options.remove_glyphs = self.options.remove_glyphs
                 ttf2otf_converter.options.check_outlines = self.options.check_outlines
                 generic_info_message("Converting outlines")
                 cff_font = ttf2otf_converter.run()

--- a/ftCLI/commands/ftcli_metrics.py
+++ b/ftCLI/commands/ftcli_metrics.py
@@ -162,12 +162,12 @@ def align(input_path, with_linegap=False, outputDir=None, recalcTimestamp=False,
             os2_modified = os2_table_copy != font.os_2_table
 
             if hhea_modified or os2_modified:
-                output_file = makeOutputFileName(font.file, outputDir=output_dir, overWrite=overWrite)
+                output_file = makeOutputFileName(font.reader.file.name, outputDir=output_dir, overWrite=overWrite)
                 font.save(output_file)
-                file_saved_message(font.file)
+                file_saved_message(output_file)
 
             else:
-                file_not_changed_message(font.file)
+                file_not_changed_message(font.reader.file.name)
 
         except Exception as e:
             generic_error_message(e)

--- a/ftCLI/commands/ftcli_utils.py
+++ b/ftCLI/commands/ftcli_utils.py
@@ -185,7 +185,7 @@ def font_renamer(input_path, source):
                 if source in (4, 5):
                     source = 1
 
-            old_file_name, old_extension = os.path.splitext(os.path.basename(font.file))
+            old_file_name, old_extension = os.path.splitext(os.path.basename(file))
 
             new_file_name = sanitize_filename(font.get_file_name(source=source), platform="auto")
             new_extension = font.get_real_extension()
@@ -284,7 +284,7 @@ def ttf_autohint(input_path, outputDir=None, recalcTimestamp=False, overWrite=Tr
             hinted_font = Font(BytesIO(data))
             if recalcTimestamp is False:
                 hinted_font.head_table.modified = font.get_modified_timestamp()
-            output_file = makeOutputFileName(font.file, outputDir=output_dir, overWrite=overWrite)
+            output_file = makeOutputFileName(file, outputDir=output_dir, overWrite=overWrite)
             hinted_font.save(output_file)
             file_saved_message(output_file)
         except Exception as e:
@@ -391,7 +391,7 @@ def ttf_remove_overlaps(input_path, ignore_errors, outputDir=None, recalcTimesta
     for file in files:
         try:
             font = Font(file, recalcTimestamp=recalcTimestamp)
-            output_file = makeOutputFileName(font.file, outputDir=output_dir, overWrite=overWrite)
+            output_file = makeOutputFileName(file, outputDir=output_dir, overWrite=overWrite)
             removeOverlaps(font, removeHinting=True, ignoreErrors=ignore_errors)
             font.save(output_file)
             file_saved_message(output_file)
@@ -421,7 +421,7 @@ def cff_check_outlines(input_path, outputDir=None, recalcTimestamp=False, overWr
         generic_info_message(f"Checking file {os.path.basename(file)}")
         try:
             font = Font(file, recalcTimestamp=recalcTimestamp)
-            output_file = makeOutputFileName(font.file, outputDir=output_dir, overWrite=overWrite)
+            output_file = makeOutputFileName(file, outputDir=output_dir, overWrite=overWrite)
             font.save(output_file)
             checkoutlinesufo.run(args=[output_file, "--error-correction-mode", "--quiet-mode"])
             file_saved_message(output_file)


### PR DESCRIPTION
- Lib/Convertes/ttf_to_otf: use the correct option `remove_glyphs` instead of the old `purge_glyphs`
- commands/ftcli_metrics, commands_ftcli_utils: remove all references to font.file in order to get rid of Font.file attribute in the future