### PR TITLE
Disable automatic tagging in bump version configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ Homepage = "https://github.com/ftCLI/FoundryTools-CLI"
 [tool.bumpversion]
 current_version = "2.0.6"
 commit = false
-tag = true
+tag = false
 
 [[tool.bumpversion.files]]
 filename = "src/foundrytools_cli/__init__.py"


### PR DESCRIPTION
This pull request makes a minor configuration change to the `pyproject.toml` file, updating the bumpversion tool settings to disable automatic tagging when bumping the version.